### PR TITLE
2 packages from erikmd/learn-ocaml-release-preflight at 0.13.2

### DIFF
--- a/packages/learn-ocaml-client/learn-ocaml-client.0.13.2/opam
+++ b/packages/learn-ocaml-client/learn-ocaml-client.0.13.2/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "The learn-ocaml client"
+description: """\
+This contains the binaries to interact with the learn-ocaml
+platform from the command line."""
+maintainer: "Yann Régis-Gianas"
+authors: [
+  "Benjamin Canou (OCamlPro)"
+  "Çağdaş Bozman (OCamlPro)"
+  "Grégoire Henry (OCamlPro)"
+  "Louis Gesbert (OCamlPro)"
+  "Pierrick Couderc (OCamlPro)"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-sf/learn-ocaml"
+bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
+depends: [
+  "base" {>= "v0.9.4"}
+  "base64"
+  "cmdliner"
+  "omd" {<= "1.3.1"}
+  "asak"
+  "gg"
+  "vg"
+  "cohttp" {>= "2.0.0"}
+  "cohttp-lwt-unix" {>= "2.0.0"}
+  "ssl" {= "0.5.5"}
+  "digestif" {>= "0.7.1"}
+  "dune"
+  "ezjsonm"
+  "lwt" {>= "4.0.0"}
+  "lwt_ssl"
+  "ocaml" {(>= "4.12") & (< "4.13~")}
+  "ocamlfind" {build}
+  "ocp-indent-nlfork"
+  "ocp-ocamlres" {>= "0.4"}
+  "ocplib-json-typed" {>= "0.7"}
+  "ipaddr" {= "2.8.0"}
+  "cstruct" {>= "3.3.0"}
+  "ppx_tools"
+  "ppx_sexp_conv"
+  "ppx_fields_conv"
+]
+build: ["dune" "build" "@install" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
+url {
+  src:
+    "https://github.com/erikmd/learn-ocaml-release-preflight/archive/v0.13.2.tar.gz"
+  checksum: [
+    "md5=604b81622b6e7baa0b999810a1bd26a0"
+    "sha512=4c7a13f1870a4276c141d688c0f9c0cb9b64bb8f2bc60db38ed9dd8b22f937bcbe21990f9881d20a758c4522c4dea3007205b6d145e10cf2060a8ec8b2d1add9"
+  ]
+}

--- a/packages/learn-ocaml/learn-ocaml.0.13.2/opam
+++ b/packages/learn-ocaml/learn-ocaml.0.13.2/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+synopsis: "The learn-ocaml online platform (engine)"
+description: """\
+This contains the binaries forming the engine for the learn-ocaml platform, and
+the common files. A demo exercise repository is also provided as example."""
+maintainer: "Yann Régis-Gianas"
+authors: [
+  "Benjamin Canou (OCamlPro)"
+  "Çağdaş Bozman (OCamlPro)"
+  "Grégoire Henry (OCamlPro)"
+  "Louis Gesbert (OCamlPro)"
+  "Pierrick Couderc (OCamlPro)"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-sf/learn-ocaml"
+bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
+depends: [
+  "base" {>= "v0.9.4"}
+  "base64"
+  "cmdliner"
+  "cohttp" {>= "2.0.0"}
+  "cohttp-lwt" {>= "2.0.0"}
+  "cohttp-lwt-unix" {>= "2.0.0"}
+  "conf-git"
+  "decompress" {= "0.8.1"}
+  "digestif" {>= "0.7.1"}
+  "dune" {>= "1.11.4"}
+  "easy-format" {>= "1.3.0"}
+  "ipaddr" {>= "2.8.0"}
+  "ezjsonm"
+  "js_of_ocaml" {>= "3.3.0" & != "3.10.0"}
+  "js_of_ocaml-compiler" {>= "3.3.0"}
+  "js_of_ocaml-lwt"
+  "js_of_ocaml-ppx"
+  "js_of_ocaml-toplevel"
+  "js_of_ocaml-tyxml"
+  "lwt" {>= "4.0.0"}
+  "lwt_react"
+  "lwt_ssl"
+  "ssl" {= "0.5.5"}
+  "magic-mime"
+  "markup"
+  "markup-lwt"
+  "ocaml" {(>= "4.12") & (< "4.13~")}
+  "ocamlfind" {build}
+  "ocp-indent-nlfork"
+  "ocp-ocamlres" {= "0.4"}
+  "ocplib-json-typed" {>= "0.6"}
+  "ocplib-json-typed-browser" {>= "0.6"}
+  "odoc" {build}
+  "omd"
+  "pprint"
+  "ppx_cstruct"
+  "ppx_tools"
+  "re"
+  "uutf" {>= "1.0"}
+  "vg"
+  "yojson" {>= "1.4.0"}
+  "asak" {>= "0.1"}
+]
+build: [
+  [make "static"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+install: [
+  ["mkdir" "-p" "%{_:share}%"]
+  ["cp" "-r" "demo-repository" "%{_:share}%/repository"]
+]
+dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
+url {
+  src:
+    "https://github.com/erikmd/learn-ocaml-release-preflight/archive/v0.13.2.tar.gz"
+  checksum: [
+    "md5=604b81622b6e7baa0b999810a1bd26a0"
+    "sha512=4c7a13f1870a4276c141d688c0f9c0cb9b64bb8f2bc60db38ed9dd8b22f937bcbe21990f9881d20a758c4522c4dea3007205b6d145e10cf2060a8ec8b2d1add9"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`learn-ocaml.0.13.2`: The learn-ocaml online platform (engine)
-`learn-ocaml-client.0.13.2`: The learn-ocaml client



---
* Homepage: https://github.com/ocaml-sf/learn-ocaml
* Source repo: git+https://github.com/ocaml-sf/learn-ocaml
* Bug tracker: https://github.com/ocaml-sf/learn-ocaml/issues

---
# Release test


---
:camel: Pull-request generated by opam-publish v2.1.0