### PR TITLE
2 packages from erikmd/learn-ocaml-release-preflight at 0.14.0

### DIFF
--- a/packages/learn-ocaml-client/learn-ocaml-client.0.14.0/opam
+++ b/packages/learn-ocaml-client/learn-ocaml-client.0.14.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "The learn-ocaml client"
+description: """\
+This contains the binaries to interact with the learn-ocaml
+platform from the command line."""
+maintainer: "Yann Régis-Gianas"
+authors: [
+  "Benjamin Canou (OCamlPro)"
+  "Çağdaş Bozman (OCamlPro)"
+  "Grégoire Henry (OCamlPro)"
+  "Louis Gesbert (OCamlPro)"
+  "Pierrick Couderc (OCamlPro)"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-sf/learn-ocaml"
+bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
+depends: [
+  "base" {>= "v0.9.4"}
+  "base64"
+  "cmdliner"
+  "omd" {<= "1.3.1"}
+  "asak"
+  "gg"
+  "vg"
+  "cohttp" {>= "2.0.0"}
+  "cohttp-lwt-unix" {>= "2.0.0"}
+  "ssl" {= "0.5.5"}
+  "digestif" {>= "0.7.1"}
+  "dune"
+  "ezjsonm"
+  "lwt" {>= "4.0.0"}
+  "lwt_ssl"
+  "ocaml" {(>= "4.12") & (< "4.13~")}
+  "ocamlfind" {build}
+  "ocp-indent-nlfork"
+  "ocp-ocamlres" {>= "0.4"}
+  "ocplib-json-typed" {>= "0.7"}
+  "ipaddr" {= "2.8.0"}
+  "cstruct" {>= "3.3.0"}
+  "ppx_tools"
+  "ppx_sexp_conv"
+  "ppx_fields_conv"
+]
+build: ["dune" "build" "@install" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
+url {
+  src:
+    "https://github.com/erikmd/learn-ocaml-release-preflight/archive/v0.14.0.tar.gz"
+  checksum: [
+    "md5=84d0b524fd057c99c9dc048680844efe"
+    "sha512=59b6e626bae6f8ff916cd7f2a5f505bbad91925803cc0398f3c8d14dd7169d1db5a0ce5812b163cf5c512d54866dbbd4ac108620cc8ef1b5823e5eaded6e0ef9"
+  ]
+}

--- a/packages/learn-ocaml/learn-ocaml.0.14.0/opam
+++ b/packages/learn-ocaml/learn-ocaml.0.14.0/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+synopsis: "The learn-ocaml online platform (engine)"
+description: """\
+This contains the binaries forming the engine for the learn-ocaml platform, and
+the common files. A demo exercise repository is also provided as example."""
+maintainer: "Yann Régis-Gianas"
+authors: [
+  "Benjamin Canou (OCamlPro)"
+  "Çağdaş Bozman (OCamlPro)"
+  "Grégoire Henry (OCamlPro)"
+  "Louis Gesbert (OCamlPro)"
+  "Pierrick Couderc (OCamlPro)"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-sf/learn-ocaml"
+bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
+depends: [
+  "base" {>= "v0.9.4"}
+  "base64"
+  "cmdliner"
+  "cohttp" {>= "2.0.0"}
+  "cohttp-lwt" {>= "2.0.0"}
+  "cohttp-lwt-unix" {>= "2.0.0"}
+  "conf-git"
+  "decompress" {= "0.8.1"}
+  "digestif" {>= "0.7.1"}
+  "dune" {>= "1.11.4"}
+  "easy-format" {>= "1.3.0"}
+  "ipaddr" {>= "2.8.0"}
+  "ezjsonm"
+  "js_of_ocaml" {>= "3.3.0" & != "3.10.0"}
+  "js_of_ocaml-compiler" {>= "3.3.0"}
+  "js_of_ocaml-lwt"
+  "js_of_ocaml-ppx"
+  "js_of_ocaml-toplevel"
+  "js_of_ocaml-tyxml"
+  "lwt" {>= "4.0.0"}
+  "lwt_react"
+  "lwt_ssl"
+  "ssl" {= "0.5.5"}
+  "magic-mime"
+  "markup"
+  "markup-lwt"
+  "ocaml" {(>= "4.12") & (< "4.13~")}
+  "ocamlfind" {build}
+  "ocp-indent-nlfork"
+  "ocp-ocamlres" {= "0.4"}
+  "ocplib-json-typed" {>= "0.6"}
+  "ocplib-json-typed-browser" {>= "0.6"}
+  "odoc" {build}
+  "omd"
+  "pprint"
+  "ppx_cstruct"
+  "ppx_tools"
+  "re"
+  "uutf" {>= "1.0"}
+  "vg"
+  "yojson" {>= "1.4.0"}
+  "asak" {>= "0.1"}
+]
+build: [
+  [make "static"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+install: [
+  ["mkdir" "-p" "%{_:share}%"]
+  ["cp" "-r" "demo-repository" "%{_:share}%/repository"]
+]
+dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
+url {
+  src:
+    "https://github.com/erikmd/learn-ocaml-release-preflight/archive/v0.14.0.tar.gz"
+  checksum: [
+    "md5=84d0b524fd057c99c9dc048680844efe"
+    "sha512=59b6e626bae6f8ff916cd7f2a5f505bbad91925803cc0398f3c8d14dd7169d1db5a0ce5812b163cf5c512d54866dbbd4ac108620cc8ef1b5823e5eaded6e0ef9"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`learn-ocaml.0.14.0`: The learn-ocaml online platform (engine)
-`learn-ocaml-client.0.14.0`: The learn-ocaml client



---
* Homepage: https://github.com/ocaml-sf/learn-ocaml
* Source repo: git+https://github.com/ocaml-sf/learn-ocaml
* Bug tracker: https://github.com/ocaml-sf/learn-ocaml/issues

---


### Bug Fixes

* release.yml / add-binaries ([bc6377d](https://www.github.com/erikmd/learn-ocaml-release-preflight/commit/bc6377d8a4f84d496501ca156b2c5c3b17db8690))
* release.yml and *.exp ([9bc4c39](https://www.github.com/erikmd/learn-ocaml-release-preflight/commit/9bc4c39f7f59f3345c1c56e6b221fc5e2f9f0b4f))


### Miscellaneous Chores

* release 0.14.0 ([bdcd4e1](https://www.github.com/erikmd/learn-ocaml-release-preflight/commit/bdcd4e1bcdd0898b6f828036a1587c75f9d337fd))


---
:camel: Pull-request generated by opam-publish v2.1.0