### PR TITLE
2 packages from ocaml-sf/learn-ocaml at 0.16.0

### DIFF
--- a/packages/learn-ocaml-client/learn-ocaml-client.0.16.0/opam
+++ b/packages/learn-ocaml-client/learn-ocaml-client.0.16.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "The learn-ocaml client"
+description: """\
+This contains the binaries to interact with the learn-ocaml
+platform from the command line."""
+maintainer: [
+  "Érik Martin-Dorel <erik.martin-dorel@irit.fr>"
+  "Yann Régis-Gianas <yann.regis-gianas@nomadic-labs.com>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+]
+authors: [
+  "Benjamin Canou (OCamlPro)"
+  "Çağdaş Bozman (OCamlPro)"
+  "Grégoire Henry (OCamlPro)"
+  "Louis Gesbert (OCamlPro)"
+  "Pierrick Couderc (OCamlPro)"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-sf/learn-ocaml"
+bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
+depends: [
+  "asak" {< "0.4"}
+  "base64"
+  "base" {>= "v0.9.4"}
+  "cmdliner" {>= "1.1.0"}
+  "cohttp" {>= "2.0.0"}
+  "cohttp-lwt-unix" {>= "2.0.0"}
+  "cstruct" {>= "3.3.0"}
+  "digestif" {>= "0.7.1"}
+  "dune" {>= "2.3.0"}
+  "ezjsonm"
+  "gg"
+  "ipaddr" {= "2.9.0"}
+  "lwt" {>= "4.0.0"}
+  "lwt_ssl"
+  "ocaml" {(>= "4.12") & (< "4.13~")}
+  "ocamlfind" {build}
+  "ocaml-migrate-parsetree" {= "1.8.0"}
+  "ocp-indent-nlfork"
+  "ocplib-json-typed" {>= "0.7"}
+  "ocp-ocamlres" {>= "0.4"}
+  "omd" {<= "1.3.1"}
+  "ppxlib"
+  "ppx_expect"
+  "ppx_inline_test"
+  "ppx_fields_conv"
+  "ppx_sexp_conv"
+  "ppx_tools"
+  "ssl" {= "0.5.12"}
+  "vg"
+]
+build: ["dune" "build" "@install" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
+url {
+  src:
+    "https://github.com/ocaml-sf/learn-ocaml/archive/refs/tags/v0.16.0.tar.gz"
+  checksum: [
+    "md5=23c47ac8ef2a9338cd41795d26566cf4"
+    "sha512=53d86304f0a6e2df8d372d80030cc1ed56887af6589a39253f53ef1e1a935cb4158c042c83c60c954c8ff70bea75bcdde9e74ee3a11cc6720f5562b9106a6088"
+  ]
+}

--- a/packages/learn-ocaml/learn-ocaml.0.16.0/opam
+++ b/packages/learn-ocaml/learn-ocaml.0.16.0/opam
@@ -1,0 +1,89 @@
+opam-version: "2.0"
+synopsis: "The learn-ocaml online platform (engine)"
+description: """\
+This contains the binaries forming the engine for the learn-ocaml platform, and
+the common files. A demo exercise repository is also provided as example."""
+maintainer: [
+  "Érik Martin-Dorel <erik.martin-dorel@irit.fr>"
+  "Yann Régis-Gianas <yann.regis-gianas@nomadic-labs.com>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+]
+authors: [
+  "Benjamin Canou (OCamlPro)"
+  "Çağdaş Bozman (OCamlPro)"
+  "Grégoire Henry (OCamlPro)"
+  "Louis Gesbert (OCamlPro)"
+  "Pierrick Couderc (OCamlPro)"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-sf/learn-ocaml"
+bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
+depends: [
+  "asak" {< "0.4"}
+  "base64"
+  "base" {>= "v0.9.4"}
+  "cmdliner" {>= "1.1.0"}
+  "cohttp" {>= "2.0.0"}
+  "cohttp-lwt" {>= "2.0.0"}
+  "cohttp-lwt-unix" {>= "2.0.0"}
+  "conf-git"
+  "decompress" {= "0.8.1"}
+  "digestif" {>= "0.7.1"}
+  "dune" {>= "2.3.0"}
+  "easy-format" {>= "1.3.0"}
+  "ezjsonm"
+  "ipaddr" {= "2.9.0"}
+  "js_of_ocaml" {>= "3.3.0" & != "3.10.0"}
+  "js_of_ocaml-compiler" {>= "3.3.0"}
+  "js_of_ocaml-lwt"
+  "js_of_ocaml-ppx"
+  "js_of_ocaml-toplevel"
+  "js_of_ocaml-tyxml"
+  "lwt" {>= "4.0.0"}
+  "lwt_react"
+  "lwt_ssl"
+  "magic-mime"
+  "markup"
+  "markup-lwt"
+  "ocaml" {(>= "4.12") & (< "4.13~")}
+  "ocamlfind" {build}
+  "ocaml-migrate-parsetree" {= "1.8.0"}
+  "ocp-indent-nlfork"
+  "ocplib-json-typed" {>= "0.7"}
+  "ocplib-json-typed-browser" {>= "0.7"}
+  "ocp-ocamlres" {>= "0.4"}
+  "odoc" {build}
+  "omd" {<= "1.3.1"}
+  "pprint"
+  "ppxlib"
+  "ppx_cstruct"
+  "ppx_expect"
+  "ppx_inline_test"
+  "ppx_sexp_conv"
+  "ppx_tools"
+  "ppx_tools_versioned"
+  "re"
+  "ssl" {= "0.5.12"}
+  "uutf" {>= "1.0"}
+  "vg"
+  "yojson" {>= "1.4.0"}
+]
+build: [
+  [make "static"]
+  ["dune" "build" "-p" name "-j" jobs]
+  [make "detect-libs"] {with-test}
+]
+run-test: [make "test"]
+install: [
+  ["mkdir" "-p" "%{_:share}%"]
+  ["cp" "-r" "demo-repository" "%{_:share}%/repository"]
+]
+dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
+url {
+  src:
+    "https://github.com/ocaml-sf/learn-ocaml/archive/refs/tags/v0.16.0.tar.gz"
+  checksum: [
+    "md5=23c47ac8ef2a9338cd41795d26566cf4"
+    "sha512=53d86304f0a6e2df8d372d80030cc1ed56887af6589a39253f53ef1e1a935cb4158c042c83c60c954c8ff70bea75bcdde9e74ee3a11cc6720f5562b9106a6088"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `learn-ocaml.0.16.0`: The learn-ocaml online platform (engine)
- `learn-ocaml-client.0.16.0`: The learn-ocaml client



---
* Homepage: https://github.com/ocaml-sf/learn-ocaml
* Source repo: git+https://github.com/ocaml-sf/learn-ocaml
* Bug tracker: https://github.com/ocaml-sf/learn-ocaml/issues

---
Cc @erikmd

## [1.0.0](https://github.com/ocaml-sf/learn-ocaml/compare/v0.16.0...v1.0.0) (2024-02-12)

Preflight!

### Features

* **pre-compilation:** Implement pre-compilation of exercises and graders ([b03bdfe](https://github.com/ocaml-sf/learn-ocaml/commit/b03bdfe5a7c9ed5d4677b1ee2eb11d37e953cbe3))
* etc.


---
:camel: Pull-request generated by opam-publish v2.3.0